### PR TITLE
enable with_zlib and with_ssl options by default

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -15,7 +15,7 @@ class MysqlConnectorCConan(ConanFile):
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False], "with_ssl": [True, False], "with_zlib": [True, False]}
-    default_options = "shared=False", "with_ssl=False", "with_zlib=False"
+    default_options = "shared=False", "with_ssl=True", "with_zlib=True"
 
     def requirements(self):
         if self.options.with_ssl:


### PR DESCRIPTION
zlib and ssl are mandatory parts of mysql connector.
When with_zlib/ssl option is false, a bundled version is used.