### PR TITLE
enable missing CI configurations

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ build: false
 
 environment:
     PYTHON_HOME: "C:\\Python37"
-    CONAN_TOTAL_PAGES: 4
 
     matrix:
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015


### PR DESCRIPTION
with CONAN_TOTAL_PAGES=4, only half of the configurations were being built (the static ones)